### PR TITLE
fix: 修复 Gemini 无法自动发送的问题

### DIFF
--- a/content-script.js
+++ b/content-script.js
@@ -45,8 +45,9 @@ async function sendToChatGPT(text) {
 
 async function sendToGemini(text) {
   const inputBox =
+    document.querySelector(".ql-editor[contenteditable='true']") ||
     document.querySelector("rich-textarea div[contenteditable='true']") ||
-    document.querySelector("div[contenteditable='true']");
+    document.querySelector("div[contenteditable='true'][role='textbox']");
 
   if (!inputBox) {
     throw new Error("未找到 Gemini 输入框");
@@ -54,24 +55,49 @@ async function sendToGemini(text) {
 
   inputBox.focus();
   clearEditable(inputBox);
+  await sleep(100);
 
-  if (!document.execCommand("insertText", false, text)) {
-    inputBox.textContent = text;
-  }
+  const paragraph = document.createElement("p");
+  paragraph.textContent = text;
+  inputBox.appendChild(paragraph);
 
-  fireInputEvents(inputBox);
-  await sleep(500);
+  inputBox.dispatchEvent(new InputEvent("beforeinput", {
+    bubbles: true,
+    cancelable: true,
+    inputType: "insertText",
+    data: text
+  }));
+  inputBox.dispatchEvent(new InputEvent("input", {
+    bubbles: true,
+    cancelable: false,
+    inputType: "insertText",
+    data: text
+  }));
+  inputBox.dispatchEvent(new Event("change", { bubbles: true }));
+
+  await sleep(600);
 
   const sendButton =
+    document.querySelector("button.send-button") ||
     document.querySelector("button[aria-label='Send message']") ||
-    document.querySelector("button[aria-label*='Send']");
+    document.querySelector("button[aria-label='发送']") ||
+    document.querySelector("button[aria-label*='Send']") ||
+    document.querySelector("button[aria-label*='发送']");
 
-  if (!sendButton) {
-    throw new Error("未找到 Gemini 发送按钮");
+  if (sendButton) {
+    sendButton.click();
+    return "Gemini 已发送";
   }
 
-  sendButton.click();
-  return "Gemini 已发送";
+  inputBox.dispatchEvent(new KeyboardEvent("keydown", {
+    key: "Enter",
+    code: "Enter",
+    keyCode: 13,
+    which: 13,
+    bubbles: true,
+    cancelable: true
+  }));
+  return "Gemini 已尝试回车发送";
 }
 
 async function sendToClaude(text) {


### PR DESCRIPTION
## 问题描述

使用 Prism 向 Gemini 发送消息时，文字会停留在输入框中，无法触发自动发送。

## 原因分析

Gemini 页面已将输入框从 `rich-textarea` 迁移到 **Quill 编辑器**（`.ql-editor`），导致原有逻辑失效：

1. **输入框选择器过时** — `rich-textarea div[contenteditable='true']` 无法匹配新的 `.ql-editor` 元素
2. **文本输入方式不兼容** — `document.execCommand("insertText")` 和直接设置 `textContent` 无法触发 Quill 的内部状态同步，框架"不知道"内容已变化，发送按钮始终不激活
3. **发送按钮选择器过时** — 按钮的 `aria-label` 已改为本地化文本（如中文"发送"），且新增了 `send-button` class，原代码只匹配英文 `Send message` / `Send`

## 修复内容

- 输入框选择器优先匹配 `.ql-editor[contenteditable='true']`，保留旧选择器作为回退
- 文本输入改为 DOM 插入 `<p>` 元素 + 触发 `beforeinput` / `input` 事件（含 `inputType: "insertText"`），正确模拟用户输入让 Quill 同步状态
- 发送按钮选择器优先用 `button.send-button` class 匹配，同时支持中英文 `aria-label`
- 找不到发送按钮时回退为模拟 Enter 键发送，增强鲁棒性

## 测试验证

在 Gemini 页面上实际执行修复后的逻辑，确认：
- ✅ 输入框正确定位（`.ql-editor`）
- ✅ 文本成功写入且 Quill 状态同步
- ✅ 发送按钮正确出现且可点击（`aria-label: "发送"`, `disabled: false`）